### PR TITLE
add support for building wasm32 target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,13 @@ keywords = ["property", "propcheck", "arbitrary", "fuzz", "testing"]
 readme = "README.md"
 
 [dependencies]
-proptest = "1.0.0"
 arbitrary = "1.1.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+proptest = "1.7.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+proptest = { version = "1.7.0", default-features = false, features = ["std"] }
+# convince getrandom to build for wasm target.
+# note that there is also a flag in .cargo/config.toml
+getrandom = { version = "0.3", features = ["wasm_js"] }


### PR DESCRIPTION
Building for wasm32 target was failing, which is problematic for building a downstream crate with proptests that use arbitrary.    Both proptest and getrandom crates support wasm32 but they require some convincing to do so.  This PR convinces them.

### Before
```
$ cargo build --target wasm32-unknown-unknown
   Compiling getrandom v0.3.3
   Compiling cfg-if v1.0.1
   Compiling zerocopy v0.8.26
   Compiling autocfg v1.5.0
   Compiling fastrand v2.3.0
   Compiling once_cell v1.21.3
   Compiling tempfile v3.20.0
error: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" configuration flag. Note that enabling the `wasm_js` feature flag alone is insufficient. For more information see: https://docs.rs/getrandom/0.3.3/#webassembly-support
   --> /home/danda/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.3.3/src/backends.rs:168:9
    |
168 | /         compile_error!(concat!(
169 | |             "The wasm32-unknown-unknown targets are not supported by default; \
170 | |             you may need to enable the \"wasm_js\" configuration flag. Note \
171 | |             that enabling the `wasm_js` feature flag alone is insufficient. \
172 | |             For more information see: \
173 | |             https://docs.rs/getrandom/", env!("CARGO_PKG_VERSION"), "/#webassembly-support"
174 | |         ));
    | |__________^

error[E0425]: cannot find function `fill_inner` in module `backends`
  --> /home/danda/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.3.3/src/lib.rs:99:19
   |
99 |         backends::fill_inner(dest)?;
   |                   ^^^^^^^^^^ not found in `backends`

error[E0425]: cannot find function `inner_u32` in module `backends`
   --> /home/danda/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.3.3/src/lib.rs:128:15
    |
128 |     backends::inner_u32()
    |               ^^^^^^^^^ not found in `backends`
    |
help: consider importing this function
    |
33  + use crate::util::inner_u32;
    |
help: if you import `inner_u32`, refer to it directly
    |
128 -     backends::inner_u32()
128 +     inner_u32()
    |

error[E0425]: cannot find function `inner_u64` in module `backends`
   --> /home/danda/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.3.3/src/lib.rs:142:15
    |
142 |     backends::inner_u64()
    |               ^^^^^^^^^ not found in `backends`
    |
help: consider importing this function
    |
33  + use crate::util::inner_u64;
    |
help: if you import `inner_u64`, refer to it directly
    |
142 -     backends::inner_u64()
142 +     inner_u64()
    |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `getrandom` (lib) due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
````

### After
```
$ cargo build --target wasm32-unknown-unknown
   Compiling unicode-ident v1.0.18
   Compiling proc-macro2 v1.0.95
   Compiling wasm-bindgen-shared v0.2.100
   Compiling bumpalo v3.18.1
   Compiling log v0.4.27
   Compiling wasm-bindgen v0.2.100
   Compiling getrandom v0.3.3
   Compiling once_cell v1.21.3
   Compiling cfg-if v1.0.1
   Compiling zerocopy v0.8.26
   Compiling autocfg v1.5.0
   Compiling bitflags v2.9.1
   Compiling regex-syntax v0.8.5
   Compiling quote v1.0.40
   Compiling syn v2.0.103
   Compiling num-traits v0.2.19
   Compiling lazy_static v1.5.0
   Compiling unarray v0.1.4
   Compiling arbitrary v1.4.1
   Compiling ppv-lite86 v0.2.21
   Compiling wasm-bindgen-backend v0.2.100
   Compiling wasm-bindgen-macro-support v0.2.100
   Compiling wasm-bindgen-macro v0.2.100
   Compiling rand_core v0.9.3
   Compiling rand v0.9.1
   Compiling rand_xorshift v0.4.0
   Compiling rand_chacha v0.9.0
   Compiling proptest v1.7.0
   Compiling proptest-arbitrary-interop v0.1.0 (/home/danda/dev/neptune/proptest-arbitrary-interop)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.66s
```